### PR TITLE
Add reference to the GitHub repo on overview page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -16,6 +16,13 @@ and time and resources you have available.
 The aim of this page is to clearly describe all the activities and
 materials so you can make an appropriate choice for your needs.
 
+| This website is generated from https://github.com/iiasa/ece-teaching using `Sphinx`_.
+| The source code of the website is released under the `MIT License`_.
+
+.. _Sphinx : http://www.sphinx-doc.org/
+
+.. _`MIT License` : https://github.com/iiasa/ece-teaching/blob/main/LICENSE
+
 .. contents:: Table of Content
    :local:
 


### PR DESCRIPTION
To highlight that we're not just having a website but also building the website in line with the medicine that we postulate, this PR adds a reference to the GitHub repo on the overview page.