### PR TITLE
Information of course: Global energy transition

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -57,9 +57,12 @@ Take a look - no need to enroll!
 
    lectures/osesm-tuwien/index
    lectures/iam-ntnu/index
+   lectures/global-entrans-tuwien/index
 
 - :doc:`lectures/osesm-tuwien/index` by Daniel Huppmann (2019-ongoing)
 - :doc:`lectures/iam-ntnu/index` by Volker Krey (2019/2020-ongoing)
+- :doc:`lectures/global-entrans-tuwien/index` by Behnam Zakeri (2020/2021-ongoing)
+
 
 Other useful resources
 ----------------------

--- a/lectures/global-entrans-tuwien/index.rst
+++ b/lectures/global-entrans-tuwien/index.rst
@@ -1,0 +1,62 @@
+Global Energy Transitions and Climate Policy @ TU Wien
+============================================
+
+.. figure:: ../../../../_static/tuwien_logo.png
+   :width: 240px
+   :align: right
+
+This course is part of the Master's Degree Program in `Environmental Technology & International Affairs`_ 
+held in Technical University Vienna (TU Wien) since spring 2021.
+The course is designed and delivered by `Dr. Behnam Zakeri <https://www.iiasa.ac.at/staff/zakeri>`_,
+including two lectures given by guest speakers Dr. Kavita Surana and Franziska Menten (MSc.).
+
+.. _`Environmental Technology & International Affairs` : https://www.tuwien.at/en/ace/masters-programs/msc-environmental-technology-intl-affairs?L=1
+
+Scope
+^^^^^
+
+The course offers a general overview on drivers and impacts of global energy transitions.
+Governing principles of international energy markets are reviewed briefly.
+Enablers and barriers of global energy transitions are discussed, including
+technological innovations, socio-behavioral aspects, and economic/political perspectives.
+Some contemporary topics in global energy transitions, such as, energy access and poverty,
+and energy and digitalization are discussed too. International environmental and climate agreements
+are reviewed, with a practical view on monitoring and implementation. The course is multi-disciplinary,
+suitable for students with different backgrounds, including but not limited to engineering, science, economics, and politics.
+
+
+Course material (March 2021)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+|cc-by|
+
+**Lecture 1**: Global energy resources and markets
+| `pdf (2.4MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-1_Global-energy-resources-and-markets.pdf>`_
+
+
+**Lecture 2**: Contemporary topics in energy and climate change
+| `pdf (1.9MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-2_Contemporary-topics.pdf>`_
+
+
+**Lecture 3**: Integration of renewable energy sources: energy storage systems
+| `pdf (2.8MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-3_Renewable-energy-and-storage.pdf>`_
+
+
+**Lecture 4**: Energy innovation and energy transitions (by Dr. Kavita Surana)
+| `pdf (9.8MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-4_Energy-innovation.pdf>`_
+
+
+**Lecture 5**: International environmental and climate agreements (co-lectured with Franziska Menten (MSc.))
+| `pdf (3.7MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-5_International-agreements.pdf>`_
+
+
+
+Acknowledgement
+^^^^^^^^^^^^^^^
+
+The material for Lecture 2 is in parts adopted from the course "Multidisciplinary Perspectives on Energy",
+lectured by Prof. Peter Lund, Aalto University, Finland. Many thanks to invited speakers in 2021, Dr. Kavita Surana,
+School of Public Policy, University of Maryland, and Franziska Menten (MSc.), United Nations Industrial Development Organization (UNIDO).
+Also, special thanks to Isabelle Starlinger (MSc.) (Program Coordinator) and Prof. Hans Puxbaum (Program Director)
+for including this course in the Master's Degree Program.
+

--- a/lectures/global-entrans-tuwien/index.rst
+++ b/lectures/global-entrans-tuwien/index.rst
@@ -34,8 +34,8 @@ Course material (March 2021)
 | `pdf (2.4MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-1_Global-energy-resources-and-markets.pdf>`_
 
 
-**Lecture 2**: Contemporary topics in energy and climate change
-| `pdf (1.9MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-2_Contemporary-topics.pdf>`_
+**Lecture 2**: Energy transitions: societal and individual perspectives
+| `pdf (1.9MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-2_Energy-transitions-society.pdf>`_
 
 
 **Lecture 3**: Integration of renewable energy sources: energy storage systems

--- a/lectures/global-entrans-tuwien/index.rst
+++ b/lectures/global-entrans-tuwien/index.rst
@@ -6,9 +6,9 @@ Global Energy Transitions and Climate Policy @ TU Wien
    :align: right
 
 This course is part of the Master's Degree Program in `Environmental Technology & International Affairs`_ 
-held in Technical University Vienna (TU Wien) since spring 2021.
+held at the Technical University Vienna (TU Wien) since spring 2021.
 The course is designed and delivered by `Dr. Behnam Zakeri <https://www.iiasa.ac.at/staff/zakeri>`_,
-including two lectures given by guest speakers Dr. Kavita Surana and Franziska Menten (MSc.).
+including two lectures given by guest speakers Dr. Kavita Surana and Franziska Menten (MSc).
 
 .. _`Environmental Technology & International Affairs` : https://www.tuwien.at/en/ace/masters-programs/msc-environmental-technology-intl-affairs?L=1
 
@@ -30,25 +30,48 @@ Course material (March 2021)
 
 |cc-by|
 
-**Lecture 1**: Global energy resources and markets
-| `pdf (2.4MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-1_Global-energy-resources-and-markets.pdf>`_
+**Lecture 1: Global energy resources and markets**
+| `pdf (2.4MB) <https://data.ece.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-1_Global-energy-resources-and-markets.pdf>`_
+
+| A short note on energy and development
+| World energy mix
+| Fossil energy resources and reserves
+| International energy markets
 
 
-**Lecture 2**: Energy transitions: societal and individual perspectives
-| `pdf (1.9MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-2_Energy-transitions-society.pdf>`_
+**Lecture 2: Energy transitions: societal and individual perspectives**
+| `pdf (1.9MB) <https://data.ece.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-2_Energy-transitions-society.pdf>`_
+
+| Energy poverty and justice
+| Societal and behavioural aspects of energy use
+| Climate change and behaviour
+| Digitalization and energy use
 
 
-**Lecture 3**: Integration of renewable energy sources: energy storage systems
-| `pdf (2.8MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-3_Renewable-energy-and-storage.pdf>`_
+**Lecture 3: Integration of renewable energy sources: energy storage systems**
+| `pdf (2.8MB) <https://data.ece.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-3_Renewable-energy-and-storage.pdf>`_
 
+| Energy and climate change
+| Global trends in renewable energy
+| Potentials and challenges of variable renewables
+| Energy storage systems
+| Economics of energy storage
 
-**Lecture 4**: Energy innovation and energy transitions (by Dr. Kavita Surana)
-| `pdf (9.8MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-4_Energy-innovation.pdf>`_
+**Lecture 4: Energy innovation and energy transitions (by Dr. Kavita Surana)**
+| `pdf (9.8MB) <https://data.ece.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-4_Energy-innovation.pdf>`_
 
+| Technological change in the energy sector
+| Energy technology innovation process
+| Potentials and barriers of energy innovation
+| Global energy transitions: case of solar PV
 
-**Lecture 5**: International environmental and climate agreements (co-lectured with Franziska Menten (MSc.))
-| `pdf (3.7MB) <https://data.ene.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-5_International-agreements.pdf>`_
+**Lecture 5: International environmental and climate agreements (co-lectured with Franziska Menten (MSc))**
+| `pdf (3.7MB) <https://data.ece.iiasa.ac.at/zakeri/Lectures/Global-energy-transitions/Lecture-5_International-agreements.pdf>`_
 
+| History of climate agreements
+| Montreal Protocol: A successful international environmental agreement
+| International organizations and development
+| Project implementation and monitoring
 
 
 Acknowledgement
@@ -56,7 +79,7 @@ Acknowledgement
 
 The material for Lecture 2 is in parts adopted from the course "Multidisciplinary Perspectives on Energy",
 lectured by Prof. Peter Lund, Aalto University, Finland. Many thanks to invited speakers in 2021, Dr. Kavita Surana,
-School of Public Policy, University of Maryland, and Franziska Menten (MSc.), United Nations Industrial Development Organization (UNIDO).
-Also, special thanks to Isabelle Starlinger (MSc.) (Program Coordinator) and Prof. Hans Puxbaum (Program Director)
+School of Public Policy, University of Maryland, and Franziska Menten (MSc), United Nations Industrial Development Organization (UNIDO).
+Also, special thanks to Isabelle Starlinger (MSc) (Program Coordinator) and Prof. Hans Puxbaum (Program Director)
 for including this course in the Master's Degree Program.
 


### PR DESCRIPTION
This PR adds the information page related to the course "Global energy transition and climate policy" lectured at TU Wien. The links to the material is embedded too.