### PR TITLE
Add ECEMP video

### DIFF
--- a/tutorials/pyam.rst
+++ b/tutorials/pyam.rst
@@ -22,6 +22,28 @@ This video is part of the `IAMC Youtube channel`_.
 
 .. _`IAMC Youtube channel` : https://www.youtube.com/c/IAMCIntegratedAssessmentModelingConsortium
 
+
+European Climate and Energy Modelling Platform 2022 (October 6, 2022)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This session from the `European Climate and Energy Modelling Platform 2022`_ covered how
+to use the pyam package for simple scenario analysis, data visualization and computation
+of derived indicators. In addition, it was shown how to load scenario data directly from
+an IIASA Scenario Explorer instance (e.g., the scenario ensemble supporting the IPCC AR6
+WG3 report) into a Python computing environment for processing and analysis.
+
+.. raw:: html
+
+	<iframe width="560" height="315"src="https://www.youtube.com/watch?v=74Eyn39IVpo"
+		title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
+		clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+	</iframe>
+
+ - Presentation slides: https://zenodo.org/record/7150257 and
+ - Code: https://github.com/phackstock/ECEMP-pyam-tutorial.
+
+.. _`European Climate and Energy Modelling Platform 2022` : https://ecemp2022.b2match.io/
+
 ENGAGE Capacity Building Workshop (February 1, 2022)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/tutorials/pyam.rst
+++ b/tutorials/pyam.rst
@@ -26,7 +26,7 @@ This video is part of the `IAMC Youtube channel`_.
 European Climate and Energy Modelling Platform 2022 (October 6, 2022)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This session from the `European Climate and Energy Modelling Platform 2022`_ covered how
+This “Skills Workshop” at the `European Climate and Energy Modelling Platform 2022`_ conference (ECEMP) covered how
 to use the pyam package for simple scenario analysis, data visualization and computation
 of derived indicators. In addition, it was shown how to load scenario data directly from
 an IIASA Scenario Explorer instance (e.g., the scenario ensemble supporting the IPCC AR6


### PR DESCRIPTION
Since the videos and presentations are now live at the ECEMP website (https://ecemp2022.b2match.io/page-1091), I've linked it to the teaching site.