### PR TITLE
Fix pyam section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -41,9 +41,11 @@ learned directly - and of course to rewind as often as you like and need.
 
    message_ix_workshop
    gains_workshops
+   pyam
 
 - :doc:`message_ix_workshop`
 - :doc:`gains_workshops`
+- :doc:`pyam`
 
 University courses and lectures
 -------------------------------
@@ -98,5 +100,4 @@ such as those given as part of summer schools or individual lectures.
    tutorials/pyam
    tutorials/eeg-coding-culture
 
-- :doc:`tutorials/pyam`
 - :doc:`tutorials/eeg-coding-culture`

--- a/index.rst
+++ b/index.rst
@@ -67,9 +67,25 @@ Take a look - no need to enroll!
 - :doc:`lectures/iam-ntnu/index` by Volker Krey (2019/2020-ongoing)
 - :doc:`lectures/global-entrans-tuwien/index` by Behnam Zakeri (2020/2021-ongoing)
 
+Talks, conference presentations, summer school material
+-------------------------------------------------------
 
-Other useful resources
-----------------------
+In this section you will find a collection of talks, conference presentations
+or similar formats related to teaching and/or learning by ECE staff,
+such as those given as part of summer schools or individual lectures.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+   :caption: Talks & presentations
+
+   tutorials/eeg-coding-culture
+
+- :doc:`tutorials/eeg-coding-culture`
+
+Useful resources
+----------------
+
 This section contains a collection of various teaching and learning
 materials in different formats.
 
@@ -85,19 +101,3 @@ materials in different formats.
   with helpful tips and tricks for your daily programming life, |br|
   based on presentations during the weekly MESSAGEix meetings
 - A `template repo <https://github.com/iiasa/python-stub>`_ for IIASA Python projects
-
-Talks, conference presentations, summer school material
--------------------------------------------------------
-In this section you will find a collection of talks, conference presentations
-or similar formats related to teaching and/or learning by ECE staff,
-such as those given as part of summer schools or individual lectures.
-
-.. toctree::
-   :hidden:
-   :maxdepth: 1
-   :caption: Talks & presentations
-
-   tutorials/pyam
-   tutorials/eeg-coding-culture
-
-- :doc:`tutorials/eeg-coding-culture`

--- a/lectures/global-entrans-tuwien/index.rst
+++ b/lectures/global-entrans-tuwien/index.rst
@@ -1,5 +1,5 @@
 Global Energy Transitions and Climate Policy @ TU Wien
-============================================
+======================================================
 
 .. figure:: ../../../../_static/tuwien_logo.png
    :width: 240px

--- a/pyam.rst
+++ b/pyam.rst
@@ -1,5 +1,5 @@
-Tutorials related to the pyam package
-=====================================
+The pyam package
+================
 
 .. figure:: https://raw.githubusercontent.com/IAMconsortium/pyam/main/doc/logos/pyam-header.png
    :width: 640px
@@ -7,16 +7,18 @@ Tutorials related to the pyam package
 This page collects tutorials and presentations related to the open-source Python package
 **pyam** for scenario analysis & visualization.
 
+`Read the docs <https://pyam-iamc.readthedocs.io>`_ to learn more about the package.
 
-Short intro video about the pyam package
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Intro video about the pyam package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. raw:: html
 
-	<iframe width="560" height="315"src="https://www.youtube.com/embed/7P6hXiVqalQ"
+	<iframe width="560" height="315" src="https://www.youtube.com/embed/7P6hXiVqalQ"
 		title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
 		clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-	</iframe>
+	</iframe><br />
 
 This video is part of the `IAMC Youtube channel`_.
 
@@ -34,13 +36,15 @@ WG3 report) into a Python computing environment for processing and analysis.
 
 .. raw:: html
 
-	<iframe width="560" height="315"src="https://www.youtube.com/watch?v=74Eyn39IVpo"
+	<iframe width="560" height="315" src="https://www.youtube.com/embed/74Eyn39IVpo"
 		title="YouTube video player" frameborder="0" allow="accelerometer; autoplay;
 		clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-	</iframe>
+	</iframe><br />
+
+**Related material:**
 
  - Presentation slides: https://zenodo.org/record/7150257 and
- - Code: https://github.com/phackstock/ECEMP-pyam-tutorial.
+ - Tutorial notebook: https://github.com/phackstock/ECEMP-pyam-tutorial
 
 .. _`European Climate and Energy Modelling Platform 2022` : https://ecemp2022.b2match.io/
 


### PR DESCRIPTION
Preparing for a pyam presentation later today, I realized that the ECEMP-section was not correctly rendered. So this PR adds a fix, and also moves the pyam section to the first part of the index page - together with MESSAGEix and GAINS as a main "product" of ECE.