### PR TITLE
Move the community meeting to its own page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -42,10 +42,12 @@ learned directly - and of course to rewind as often as you like and need.
    message_ix_workshop
    gains_workshops
    pyam
+   message_ix_community_meeting
 
 - :doc:`message_ix_workshop`
 - :doc:`gains_workshops`
 - :doc:`pyam`
+- :doc:`message_ix_community_meeting`
 
 University courses and lectures
 -------------------------------

--- a/message_ix_community_meeting.rst
+++ b/message_ix_community_meeting.rst
@@ -1,0 +1,82 @@
+.. _messageix workshop:
+
+MESSAGEix Community Meeting
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Community Meeting aims to bring together researchers working on integrated assessment and/or energy system modeling using open source software. 
+
+It is a platform for showcasing new developments and features of the MESSAGEix modeling framework, sharing knowledge on various modeling approaches and applications of the framework, and discussing best practices in model-based policy analysis. The meeting is a place for facilitating collaboration between MESSAGEix users from around the world, by creating a forum where users can share their latest research outcomes and modeling experiences.
+
+The Community Meeting also aims to inspire new users of the MESSAGEix framework on the range of available possibilities and link them with other users in order to help them advance their modeling work.  
+For information about the model, its structure, mathematical
+formulation and much more, please see the `documentation <https://docs.messageix.org>`_.
+
+.. contents:: Table of Content
+   :local:
+
+Upcoming events
+""""""""""""""""
+
+* 24-25 May 2023 - MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_)
+
+Past workshops and seminars
+""""""""""""""""
+
+* 7-8 May 2022 - 1st Annual MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2022/messageix-community-meeting>`_)
+
+Learning objectives
+"""""""""""""""""""
+
+The learning objectives of the workshops are the following:
+
+* Connecting with other community members.
+* Exploring/Showcasing new applications of MESSAGEix.
+* Getting to know recent advances within MESSAGEix.
+* Understanding more complex aspects of MESSAGEix.
+* Gaining insights on interplay with related tools.
+
+Needed requirements
+"""""""""""""""""""
+
+Each workshop is designed to be accessible for users with different
+backgrounds and levels of experience with the modelling. However, there
+are some pre-requisite knowledge and skills which you should
+go through before getting started, including:
+
+* Elementary computer programming (preferably in the Python or R language);
+* Fundamental concepts of mathematical modelling, optimization,
+  and data analysis; and
+* Energy systems (e.g., energy supply, energy conversion
+  technologies, and demand sectors and their linkages).
+
+For a complete list, plus links to learning resources, see
+`“Pre-requisite knowledge & skills" repo <https://docs.messageix.org/en/stable/prereqs.html>`_
+in the documentation.
+
+Installation of MESSAGEix
+""""""""""""""""""""""
+
+Installing MESSAGEix before you're getting started with the workshop is highly
+recommended. Complete instructions are provided in the documentation on the
+`“Installation” <https://docs.messageix.org/en/stable/install.html>`_
+page of the documentation.
+
+To successfully work through this workshop, we emphasize a few points
+from the instructions:
+
+* If you are not already familiar with the other installation methods,
+  you should use Anaconda to install the framework.
+
+* Under the `“Tutorials” <https://docs.messageix.org/en/stable/tutorials.html>`_
+  page, you can download some simple models developed using MESSAGEix. To run these
+  sample models, you need to install the Jupyter notebook software from Anaconda
+  Navigator.
+
+You can check our GitHub pages, where common issues and solutions are discussed:
+https://github.com/iiasa/message_ix/discussions
+
+Agenda
+""""""
+
+Please see `the current Community Meeting page <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_ for the agenda. Kindly note that the agenda is subject to change until a month before the meeting.
+

--- a/message_ix_community_meeting.rst
+++ b/message_ix_community_meeting.rst
@@ -3,13 +3,21 @@
 MESSAGEix Community Meeting
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Community Meeting aims to bring together researchers working on integrated assessment and/or energy system modeling using open source software. 
+The Community Meeting aims to bring together researchers working on integrated 
+assessment and/or energy system modeling using open source software. 
 
-It is a platform for showcasing new developments and features of the MESSAGEix modeling framework, sharing knowledge on various modeling approaches and applications of the framework, and discussing best practices in model-based policy analysis. The meeting is a place for facilitating collaboration between MESSAGEix users from around the world, by creating a forum where users can share their latest research outcomes and modeling experiences.
+It is a platform for showcasing new developments and features of the MESSAGEix 
+modeling framework, sharing knowledge on various modeling approaches and 
+applications of the framework, and discussing best practices in model-based 
+policy analysis. The meeting is a place for facilitating collaboration between 
+MESSAGEix users from around the world, by creating a forum where users can 
+share their latest research outcomes and modeling experiences.
 
-The Community Meeting also aims to inspire new users of the MESSAGEix framework on the range of available possibilities and link them with other users in order to help them advance their modeling work.  
-For information about the model, its structure, mathematical
-formulation and much more, please see the `documentation <https://docs.messageix.org>`_.
+The Community Meeting also aims to inspire new users of the MESSAGEix framework 
+on the range of available possibilities and link them with other users in order 
+to help them advance their modeling work.  
+For information about the modeling framework, its structure, mathematical
+formulation, installation, and much more, please see the `documentation <https://docs.messageix.org>`_.
 
 .. contents:: Table of Content
    :local:
@@ -19,64 +27,26 @@ Upcoming events
 
 * 24-25 May 2023 - MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_)
 
-Past workshops and seminars
-""""""""""""""""
+Past events
+"""""""""""
 
 * 7-8 May 2022 - 1st Annual MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2022/messageix-community-meeting>`_)
 
-Learning objectives
-"""""""""""""""""""
+Objectives of the community meeting
+"""""""""""""""""""""""""""""""""""
 
-The learning objectives of the workshops are the following:
+The objectives of the community meeting are the following:
 
-* Connecting with other community members.
-* Exploring/Showcasing new applications of MESSAGEix.
-* Getting to know recent advances within MESSAGEix.
-* Understanding more complex aspects of MESSAGEix.
-* Gaining insights on interplay with related tools.
-
-Needed requirements
-"""""""""""""""""""
-
-Each workshop is designed to be accessible for users with different
-backgrounds and levels of experience with the modelling. However, there
-are some pre-requisite knowledge and skills which you should
-go through before getting started, including:
-
-* Elementary computer programming (preferably in the Python or R language);
-* Fundamental concepts of mathematical modelling, optimization,
-  and data analysis; and
-* Energy systems (e.g., energy supply, energy conversion
-  technologies, and demand sectors and their linkages).
-
-For a complete list, plus links to learning resources, see
-`“Pre-requisite knowledge & skills" repo <https://docs.messageix.org/en/stable/prereqs.html>`_
-in the documentation.
-
-Installation of MESSAGEix
-""""""""""""""""""""""
-
-Installing MESSAGEix before you're getting started with the workshop is highly
-recommended. Complete instructions are provided in the documentation on the
-`“Installation” <https://docs.messageix.org/en/stable/install.html>`_
-page of the documentation.
-
-To successfully work through this workshop, we emphasize a few points
-from the instructions:
-
-* If you are not already familiar with the other installation methods,
-  you should use Anaconda to install the framework.
-
-* Under the `“Tutorials” <https://docs.messageix.org/en/stable/tutorials.html>`_
-  page, you can download some simple models developed using MESSAGEix. To run these
-  sample models, you need to install the Jupyter notebook software from Anaconda
-  Navigator.
-
-You can check our GitHub pages, where common issues and solutions are discussed:
-https://github.com/iiasa/message_ix/discussions
+* Connecting with other community members
+* Showcasing new applications of MESSAGEix
+* Exploring recent advances and new features of MESSAGEix
+* Understanding more complex analyses within the scope of MESSAGEix
+* Gaining insights on coupling possibilities with other tools/modules
 
 Agenda
 """"""
 
-Please see `the current Community Meeting page <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_ for the agenda. Kindly note that the agenda is subject to change until a month before the meeting.
+Please see `the current Community Meeting page <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_
+for the agenda. Kindly note that the agenda is subject to change until a
+month before the meeting.
 

--- a/message_ix_workshop.rst
+++ b/message_ix_workshop.rst
@@ -19,13 +19,11 @@ Upcoming events
 """"""""""""""""
 
 * 5-7 and 12-13 June 2023 - MESSAGEix Workshop
-* 24-25 May 2023 - MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2023/messageix-community-meeting-2023>`_)
 
 Past workshops and seminars
 """"""""""""""""
 
 * 7-13 June 2022
-* 7-8 May 2022 - 1st Annual MESSAGEix Community Meeting (`more info and the agenda <https://iiasa.ac.at/events/may-2022/messageix-community-meeting>`_)
 * 7-11 June 2021 (`download <http://pure.iiasa.ac.at/id/eprint/17318/>`_)
 * 7-10 September 2020
 * 8-12 June 2020

--- a/message_ix_workshop.rst
+++ b/message_ix_workshop.rst
@@ -21,7 +21,7 @@ Upcoming events
 * 5-7 and 12-13 June 2023 - MESSAGEix Workshop
 
 Past workshops and seminars
-""""""""""""""""
+""""""""""""""""""""""""""""
 
 * 7-13 June 2022
 * 7-11 June 2021 (`download <http://pure.iiasa.ac.at/id/eprint/17318/>`_)
@@ -61,7 +61,7 @@ For a complete list, plus links to learning resources, see
 in the documentation.
 
 Installation of MESSAGEix
-""""""""""""""""""""""
+""""""""""""""""""""""""""
 
 Installing MESSAGEix before you're getting started with the workshop is highly
 recommended. Complete instructions are provided in the documentation on the


### PR DESCRIPTION
Pat asked us to update the workshop page, but I found this to be very workshop-specific, e.g. including the agenda of the workshop. Thus, it didn't seem like the right place to simply throw in a mention of the Community Meeting. Instead, this PR creates a separate CM page and deletes the mention from the workshop page.